### PR TITLE
Removed deprecated love.filesystem.exists call

### DIFF
--- a/obj_loader.lua
+++ b/obj_loader.lua
@@ -113,7 +113,7 @@ function loader.parse(object)
 end
 
 function file_exists(file)
-	if love then return love.filesystem.exists(file) end
+	if love then return love.filesystem.getInfo(file) ~= nil end
 
 	local f = io.open(file, "r")
 	if f then f:close() end


### PR DESCRIPTION
love.filesystem.exists has been deprecated since LÖVE 11.0. I replaced that call with love.filesystem.getInfo instead.